### PR TITLE
An update to prevent an infinite loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/influxdb-relay

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Usage of influxdb-relay:
   -listen-addr="127.0.0.1:4444": Local address for the UDP listener
   -max-line-length=256: Maximum line length for line protocol, in bytes
   -target-url="http://127.0.0.1:8086/write?db=example": URL where recieved data should be written
+  -attempt-limit=10: Maximum number of times to retry failed influxdb requests (0=infinite)
 ```
 
 License

--- a/main.go
+++ b/main.go
@@ -19,6 +19,9 @@ var targetURL = flag.String(
 var listenAddrStr = flag.String(
 	"listen-addr", "127.0.0.1:4444", "Local address for the UDP listener",
 )
+var attemptLimit = flag.Int(
+	"attempt-limit", 10, "Maximum number of times to retry failed influxdb requests (0=infinite)",
+)
 
 func main() {
 	flag.Parse()
@@ -62,9 +65,9 @@ func main() {
 		SendBufferQueue: sendBufferQueue,
 	}
 	writer := &Writer{
-		SendBufferQueue:   sendBufferQueue,
-		TargetURL:         *targetURL,
-		RecvBufferQueue:   recvBufferQueue,
+		SendBufferQueue: sendBufferQueue,
+		TargetURL:       *targetURL,
+		RecvBufferQueue: recvBufferQueue,
 	}
 
 	go reader.Run()


### PR DESCRIPTION
We found a malformed message can put the relay in an infinite loop (returns as a 400 error, which we discard outright). And if the upstream server is offline, we shouldn't keep trying indefinitely. A new command line switch will control how many times the relay is attempted.

(I've also configured to ignore the influxdb-relay binary.)
